### PR TITLE
Support multi-lang regex validation in 1.1.5 registration-client

### DIFF
--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/dto/SchemaDto.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/dto/SchemaDto.java
@@ -73,6 +73,8 @@ class ValidatorDto {
 	private String validator;
 	
 	private List<String> arguments;
+	
+	private String langCode;
 }
 
 @Data

--- a/admin/kernel-syncdata-service/src/main/java/io/mosip/kernel/syncdata/dto/SchemaDto.java
+++ b/admin/kernel-syncdata-service/src/main/java/io/mosip/kernel/syncdata/dto/SchemaDto.java
@@ -76,6 +76,8 @@ class ValidatorDto {
 	private String validator;
 	
 	private List<String> arguments;
+	
+	private String langCode;
 }
 
 @Data


### PR DESCRIPTION
Committing this file by making sure that validator fetches based on language code.