### PR TITLE
Removed concatenate of mandate and optional languages

### DIFF
--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/dto/ZoneUserDto.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/dto/ZoneUserDto.java
@@ -15,7 +15,6 @@ public class ZoneUserDto {
 	@StringFormatter(min = 1, max = 256)
 	private String userId;
 
-	@Deprecated
 	private String langCode;
 	
 	@NotNull

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ApplicationConfigServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ApplicationConfigServiceImpl.java
@@ -18,16 +18,13 @@ public class ApplicationConfigServiceImpl implements ApplicationConfigService {
 
 	@Value("${mosip.optional-languages}")
 	private String optionalLang;
-	
+
 	@Value("${aplication.configuration.level.version}")
 	private String version;
 	
 	@Value("${mosip.recommended.centers.locCode}")
 	private String locationHierarchyLevel;
-	
-	@Value("${mosip.supported-languages}")
-	private String supportedLanguages;
-	
+		
 	@Value("${mosip.admin.ui.configs}")
 	private String uiConfigs;
 

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/DeviceServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/DeviceServiceImpl.java
@@ -119,9 +119,6 @@ public class DeviceServiceImpl implements DeviceService {
 	@Autowired
 	private ZoneService zoneService;
 
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
-
 	@Autowired
 	private MasterdataCreationUtil masterdataCreationUtil;
 

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/DeviceSpecificationServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/DeviceSpecificationServiceImpl.java
@@ -107,8 +107,7 @@ public class DeviceSpecificationServiceImpl implements DeviceSpecificationServic
 	@Autowired
 	private MasterdataCreationUtil masterdataCreationUtil;
 	
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
+
 	/*
 	 * (non-Javadoc)
 	 * 

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ExceptionalHolidaysServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ExceptionalHolidaysServiceImpl.java
@@ -2,6 +2,7 @@ package io.mosip.kernel.masterdata.service.impl;
 
 import java.util.List;
 
+import io.mosip.kernel.masterdata.utils.LanguageUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
@@ -34,8 +35,9 @@ public class ExceptionalHolidaysServiceImpl implements ExceptionalHolidayService
 	@Autowired
 	private RegistrationCenterRepository regCenterRepo;
 
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
+	@Autowired
+	private LanguageUtils languageUtils;
+
 
 	@Cacheable(value = "exceptional-holiday", key = "'exceptionalholiday'.concat('-').concat(#regCenterId).concat('-').concat(#langCode)",
 			condition = "#regCenterId != null && #langCode != null")
@@ -45,7 +47,7 @@ public class ExceptionalHolidaysServiceImpl implements ExceptionalHolidayService
 		List<ExceptionalHolidayDto> excepHolidays = null;
 		List<ExceptionalHoliday> exeptionalHolidayList = null;
 		try {
-			if (!supportedLang.contains(langCode)) {
+			if (!languageUtils.getConfiguredLanguages().contains(langCode)) {
 				throw new MasterDataServiceException(ExceptionalHolidayErrorCode.INVALIDE_LANGCODE.getErrorCode(),
 						ExceptionalHolidayErrorCode.INVALIDE_LANGCODE.getErrorMessage());
 			}

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/GenericServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/GenericServiceImpl.java
@@ -4,6 +4,7 @@ import io.mosip.kernel.masterdata.constant.MasterdataSearchErrorCode;
 import io.mosip.kernel.masterdata.dto.MissingDataDto;
 import io.mosip.kernel.masterdata.exception.MasterDataServiceException;
 import io.mosip.kernel.masterdata.service.GenericService;
+import io.mosip.kernel.masterdata.utils.LanguageUtils;
 import io.mosip.kernel.masterdata.utils.MasterdataSearchHelper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,17 +16,17 @@ import java.util.List;
 @Service
 public class GenericServiceImpl implements GenericService {
 
-	@Value("#{'${mosip.mandatory-languages:}'.concat(',').concat('${mosip.optional-languages:}')}")
-	private String supportedLanguages;
-
 	@Autowired
 	private MasterdataSearchHelper masterdataSearchHelper;
+
+	@Autowired
+	private LanguageUtils languageUtils;
 
 	@Override
 	public List<MissingDataDto> getMissingData(Class entity, String langCode, String idFieldName, String fieldName) {
 		List<MissingDataDto> list = new ArrayList<>();
 
-		if (!supportedLanguages.contains(langCode)) {
+		if (!languageUtils.getConfiguredLanguages().contains(langCode)) {
 			throw new MasterDataServiceException(MasterdataSearchErrorCode.INVALID_LANGCODE.getErrorCode(),
 					MasterdataSearchErrorCode.INVALID_LANGCODE.getErrorMessage());
 		}

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/HolidayServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/HolidayServiceImpl.java
@@ -97,9 +97,6 @@ public class HolidayServiceImpl implements HolidayService {
 	@Autowired
 	private AuditUtil auditUtil;
 
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
-
 	private static final String UPDATE_HOLIDAY_QUERY = "UPDATE Holiday h SET h.updatedBy = :updatedBy , h.updatedDateTime = :updatedDateTime, h.holidayDesc = :holidayDesc,h.holidayId.holidayDate=:holidayDate,h.holidayId.holidayName = :holidayName   WHERE h.holidayId.locationCode = :locationCode  and h.holidayId.holidayId = :holidayId and h.holidayId.langCode = :langCode and (h.isDeleted is null or h.isDeleted = false)";
 	private static final int DEFAULT_HOLIDAY_ID = 2000001;
 
@@ -577,7 +574,7 @@ public class HolidayServiceImpl implements HolidayService {
 	/**
 	 * This method return Machine Types list filters.
 	 * 
-	 * @param machineTypes the list of Machine Type.
+	 * @param locations the list of Machine Type.
 	 * @return the list of {@link SearchFilter}.
 	 */
 	private List<SearchFilter> buildLocationSearchFilter(List<Location> locations) {
@@ -589,7 +586,7 @@ public class HolidayServiceImpl implements HolidayService {
 	/**
 	 * This method provide search filter for provided Machine Type.
 	 * 
-	 * @param machineType the machine type.
+	 * @param location the machine type.
 	 * @return the {@link SearchFilter}.
 	 */
 	private SearchFilter buildLocations(Location location) {

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/MachineServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/MachineServiceImpl.java
@@ -133,9 +133,6 @@ public class MachineServiceImpl implements MachineService {
 	@Autowired
 	private MasterdataCreationUtil masterdataCreationUtil;
 
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
-
 	@Autowired
 	private RegistrationCenterRepository regCenterRepository;
 
@@ -1007,13 +1004,13 @@ public class MachineServiceImpl implements MachineService {
 	private void updatePublicKey(String publicKey, String signPublicKey, Machine machineEntity) {
 		if(StringUtils.isNotEmpty(publicKey)) {
 			machineEntity.setPublicKey(machineUtil.getX509EncodedPublicKey(publicKey,MachineUtil.PUBLIC_KEY));
-			machineEntity.setKeyIndex(CryptoUtil.computeFingerPrint(CryptoUtil.decodeBase64(machineEntity.getPublicKey()),
+			machineEntity.setKeyIndex(CryptoUtil.computeFingerPrint(CryptoUtil.decodeURLSafeBase64(machineEntity.getPublicKey()),
 					null).toLowerCase());
 		}
 
 		if(StringUtils.isNotEmpty(signPublicKey)) {
 			machineEntity.setSignPublicKey(machineUtil.getX509EncodedPublicKey(signPublicKey,MachineUtil.SIGN_PUBLIC_KEY));
-			machineEntity.setSignKeyIndex(CryptoUtil.computeFingerPrint(CryptoUtil.decodeBase64(machineEntity.getSignPublicKey()),
+			machineEntity.setSignKeyIndex(CryptoUtil.computeFingerPrint(CryptoUtil.decodeURLSafeBase64(machineEntity.getSignPublicKey()),
 					null).toLowerCase());
 		}
 	}

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/MachineSpecificationServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/MachineSpecificationServiceImpl.java
@@ -109,9 +109,6 @@ public class MachineSpecificationServiceImpl implements MachineSpecificationServ
 
 	@Autowired
 	private MasterdataCreationUtil masterdataCreationUtil;
-	
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
 
 	/*
 	 * (non-Javadoc)

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/TemplateServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/TemplateServiceImpl.java
@@ -95,17 +95,14 @@ public class TemplateServiceImpl implements TemplateService {
 	@Autowired
 	private FilterTypeValidator filterTypeValidator;
 
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
-
 	@Value("${mosip.kernel.masterdata.template_idauthentication_event:masterdata/idauthentication_templates}")
 	private String topic;
 
 	@Value("${websub.publish.url}")
 	private String hubURL;
 
-	@Value("${mosip.kernel.masterdata.template_idauthentication_event_module_name:ID Authentication}")
-	private String idAuthModuleName;
+	@Value("${mosip.kernel.masterdata.template_idauthentication_event_module_id:10004}")
+	private String idAuthModuleId;
 
 	@Autowired
 	private FilterColumnValidator filterColumnValidator;
@@ -292,7 +289,7 @@ public class TemplateServiceImpl implements TemplateService {
 				template = masterdataCreationUtil.updateMasterData(Template.class, template);
 				MetaDataUtils.setUpdateMetaData(template, entity, false);
 				templateRepository.update(entity);
-				if (template.getModuleName().equalsIgnoreCase(idAuthModuleName)) {
+				if (template.getModuleId().equalsIgnoreCase(idAuthModuleId)) {
 					TemplateDto templateDto = MapperUtils.map(template, TemplateDto.class);
                     EventModel eventModel  =EventPublisherUtil.populateEventModel(templateDto, MasterDataConstant.PUBLISHER_ID, topic , "templates");
 					publisher.publishUpdate(topic, eventModel, MediaType.APPLICATION_JSON_UTF8_VALUE,

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ZoneUserServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ZoneUserServiceImpl.java
@@ -91,9 +91,6 @@ public class ZoneUserServiceImpl implements ZoneUserService {
 	@Autowired
 	UserDetailsRepository userDetailsRepo;
 
-	@Value("#{'${mosip.mandatory-languages:}'.concat(',').concat('${mosip.optional-languages:}')}")
-	private String supportedLang;
-
 	@Value("${zone.user.details.url}")
 	private String userDetails;
 
@@ -135,7 +132,7 @@ public class ZoneUserServiceImpl implements ZoneUserService {
 			zu = MetaDataUtils.setCreateMetaData(zoneUserDto, ZoneUser.class);
 
 			// Throws exception if not found
-			zoneservice.getZone(zoneUserDto.getZoneCode(), supportedLang.split(",")[0]);
+			zoneservice.getZone(zoneUserDto.getZoneCode(), languageUtils.getDefaultLanguage());
 
 			zu = zoneUserRepo.save(zu);
 			ZoneUserHistory zuh = new ZoneUserHistory();

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/LanguageUtils.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/LanguageUtils.java
@@ -18,14 +18,12 @@ public class LanguageUtils {
 
 	private List<String> mandatoryLang;
 	private List<String> optionalLang;
-	private List<String> configuredLanguages;
-	private List<String> supportedLangugaes;
+	private Set<String> configuredLanguages;
 
 
 	@Autowired
 	public LanguageUtils(@Value("${mosip.mandatory-languages:NOTSET}") String mandatory,
-			@Value("${mosip.optional-languages:NOTSET}") String optional,
-			@Value("${mosip.supported-languages:NOTSET}") String supported) {
+			@Value("${mosip.optional-languages:NOTSET}") String optional) {
 
 		if ("NOTSET".equals(optional)) {
 			this.optionalLang = Collections.emptyList();
@@ -39,19 +37,13 @@ public class LanguageUtils {
 			this.mandatoryLang = Arrays.asList(mandatory.split(","));
 		}
 
-
-		if ("NOTSET".equals(supported)) {
-			this.supportedLangugaes = Collections.emptyList();
-		} else {
-			this.supportedLangugaes = Arrays.asList(supported.split(","));
-		}
-		configuredLanguages = new ArrayList<>();
+		configuredLanguages = new HashSet<>();
 		configuredLanguages.addAll(mandatoryLang);
 		configuredLanguages.addAll(optionalLang);
 	}
 
 	public String getDefaultLanguage(){
-		return configuredLanguages.get(0);
+		return configuredLanguages.stream().findFirst().get();
 	}
 
 }

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/MasterdataCreationUtil.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/MasterdataCreationUtil.java
@@ -23,6 +23,7 @@ import javax.persistence.criteria.Predicate;
 import javax.persistence.criteria.Root;
 
 import org.hibernate.HibernateException;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -59,16 +60,14 @@ public class MasterdataCreationUtil {
 
 	private static String contextUser = "superadmin";
 
-
-
-	@Value("#{'${mosip.mandatory-languages:}'.concat('${mosip.optional-languages:}')}")
-	private String supportedLang;
-
 	/**
 	 * Field for interface used to interact with the persistence context.
 	 */
 	@PersistenceContext
 	private EntityManager entityManager;
+
+	@Autowired
+	private LanguageUtils languageUtils;
 
 	/**
 	 * Constructor for MasterdataSearchHelper having EntityManager
@@ -117,7 +116,7 @@ public class MasterdataCreationUtil {
 		if(langCode == null)
 			return t;
 
-		if (supportedLang.contains(langCode))
+		if (languageUtils.getConfiguredLanguages().contains(langCode))
 			return t;
 
 		throw new MasterDataServiceException(RegistrationCenterErrorCode.LANGUAGE_EXCEPTION.getErrorCode(),

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/RegistrationCenterValidator.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/RegistrationCenterValidator.java
@@ -47,18 +47,6 @@ public class RegistrationCenterValidator {
 	@Value("${mosip.min-digit-longitude-latitude:4}")
 	private int minDegits;
 
-	/**
-	 * get list of mandatory languages supported by MOSIP from configuration file
-	 */
-	@Value("${mosip.mandatory-languages}")
-	private String mandatoryLang;
-
-	/**
-	 * get list of optional languages supported by MOSIP from configuration file
-	 */
-	@Value("${mosip.optional-languages}")
-	private String optionalLang;
-
 	@Value("${mosip.recommended.centers.locCode}")
 	private String locationHierarchy;
 
@@ -73,8 +61,6 @@ public class RegistrationCenterValidator {
 
 	@PostConstruct
 	public void constructRegEx() {
-		supportedLanguages = new HashSet<>(Arrays.asList(optionalLang.split(",")));
-		supportedLanguages.addAll(Arrays.asList(mandatoryLang.split(",")));
 		negRegex = "^(\\-\\d{1,2}\\.\\d{" + minDegits + ",})$";
 		posRegex = "^(\\d{1,2}\\.\\d{" + minDegits + ",})$";
 	}

--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/ZoneUtils.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/utils/ZoneUtils.java
@@ -51,9 +51,6 @@ public class ZoneUtils {
 	@Value("mosip.kernel.masterdata.zone-heirarchy-path-delimiter:/")
 	private String hierarchyPathDelimiter;
 
-	@Value("#{'${mosip.mandatory-languages}'.concat('${mosip.optional-languages}')}")
-	private String supportedLang;
-
 
 	/**
 	 * Method to get the all the users zones based on the passed list of zone and
@@ -230,7 +227,7 @@ public class ZoneUtils {
 				List<Zone> zones = getUserZones();
 				List<Zone> langSpecificZones = null;
 				if (langCode.equals("all")) {
-					langSpecificZones = zones.stream().filter(i -> supportedLang.contains(i.getLangCode()))
+					langSpecificZones = zones.stream().filter(i -> languageUtils.getConfiguredLanguages().contains(i.getLangCode()))
 							.collect(Collectors.toList());
 				} else {
 					langSpecificZones = zones.stream().filter(i -> i.getLangCode().equals(langCode))

--- a/admin/kernel-masterdata-service/src/test/resources/application.properties
+++ b/admin/kernel-masterdata-service/src/test/resources/application.properties
@@ -22,7 +22,6 @@ mosip.supported-languages=eng,ara,fra
 
 mosip.optional-languages=ara,fra
 mosip.mandatory-languages=eng
-mosip.admin.ui.configs=mandatoryLangCode:${mosip.mandatory-languages};optionalLangCode:${mosip.optional-languages}
 mosip.recommended.centers.locCode =5
 mosip.kernel.masterdata.auth-manager-base-uri=http://localhost:8086/v1/authmanager
 #---------------------------------------Security Properties-----------------------------
@@ -402,3 +401,9 @@ mosip.centertypecode.validate.regex=^[a-zA-Z0-9]([_-](?![_-])|[a-zA-Z0-9]){0,34}
 
 mosip.kernel.applicantType.mvel.file=applicanttype.mvel
 mosip.kernel.config.server.file.storage.uri=http://localhost/config/kernel-masterdata-service/mz/develop/
+
+mosip.primary-language=eng
+mosip.secondary-language=ara
+mosip.all-languages=all
+mosip.admin.ui.configs=primaryLangCode:${mosip.primary-language};secondaryLangCode:${mosip.secondary-language};version:${aplication.configuration.level.version}
+nHierarchyLevel:${mosip.recommended.centers.locCode},supportedLanguages:${mosip.supported-languages}


### PR DESCRIPTION
Removed concatenate of mandate and optional languages, instead using getConfiguredLangs method from language utils