### PR TITLE
Enabled admin service module in build to be included in next release

### DIFF
--- a/admin/pom.xml
+++ b/admin/pom.xml
@@ -151,7 +151,7 @@
 	</properties>
 
 	<modules>
-<!-- 		<module>admin-service</module> -->
+ 		<module>admin-service</module>
 		<module>kernel-masterdata-service</module>
         <module>kernel-syncdata-service</module>
 	</modules>


### PR DESCRIPTION
We found that last release of admin service was a rc release with a bug fix, so it is reenabled here to be part of next hotfix release