### PR TITLE
 MOSIP-28461 MOSIP-28369 MOSIP-27529

### DIFF
--- a/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ValidDocumentServiceImpl.java
+++ b/admin/kernel-masterdata-service/src/main/java/io/mosip/kernel/masterdata/service/impl/ValidDocumentServiceImpl.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import javax.transaction.Transactional;
 
 import io.mosip.kernel.masterdata.dto.response.FilterResult;
+import io.mosip.kernel.masterdata.utils.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheEvict;
@@ -61,12 +62,6 @@ import io.mosip.kernel.masterdata.repository.DocumentCategoryRepository;
 import io.mosip.kernel.masterdata.repository.DocumentTypeRepository;
 import io.mosip.kernel.masterdata.repository.ValidDocumentRepository;
 import io.mosip.kernel.masterdata.service.ValidDocumentService;
-import io.mosip.kernel.masterdata.utils.MapperUtils;
-import io.mosip.kernel.masterdata.utils.MasterDataFilterHelper;
-import io.mosip.kernel.masterdata.utils.MasterdataSearchHelper;
-import io.mosip.kernel.masterdata.utils.MetaDataUtils;
-import io.mosip.kernel.masterdata.utils.OptionalFilter;
-import io.mosip.kernel.masterdata.utils.PageUtils;
 import io.mosip.kernel.masterdata.validator.FilterColumnValidator;
 import io.mosip.kernel.masterdata.validator.FilterTypeEnum;
 import io.mosip.kernel.masterdata.validator.FilterTypeValidator;
@@ -113,6 +108,9 @@ public class ValidDocumentServiceImpl implements ValidDocumentService {
 
 	@Autowired
 	private FilterTypeValidator filterTypeValidator;
+
+	@Autowired
+	private LanguageUtils languageUtils;
 	
   /*
 	 * (non-Javadoc)
@@ -127,6 +125,7 @@ public class ValidDocumentServiceImpl implements ValidDocumentService {
 
 		ValidDocument validDocument = MetaDataUtils.setCreateMetaData(document, ValidDocument.class);
 		validDocument.setIsActive(true);
+		validDocument.setLangCode(languageUtils.getDefaultLanguage()); //setting lang-code, as its required to be non-null for pre-reg (<=1.2.0.1)
 		try {
 			validDocument = documentRepository.create(validDocument);
 		} catch (DataAccessLayerException | DataAccessException e) {

--- a/admin/kernel-syncdata-service/src/main/java/io/mosip/kernel/syncdata/SyncDataBootApplication.java
+++ b/admin/kernel-syncdata-service/src/main/java/io/mosip/kernel/syncdata/SyncDataBootApplication.java
@@ -22,7 +22,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 		"io.mosip.kernel.core", "io.mosip.kernel.crypto",
 		"io.mosip.kernel.signature.service","io.mosip.kernel.clientcrypto.service.impl",
 		"io.mosip.kernel.keymanagerservice.service", "io.mosip.kernel.keymanagerservice.util",
-		"io.mosip.kernel.keymanagerservice.helper", "io.mosip.kernel.keymanager",
+		"io.mosip.kernel.keymanagerservice.helper", "io.mosip.kernel.keymanager.hsm.impl",
 		"io.mosip.kernel.cryptomanager.util", "io.mosip.kernel.partnercertservice.helper",
 		"io.mosip.kernel.partnercertservice.service", "io.mosip.kernel.websub.api.client",
 		"io.mosip.kernel.keygenerator.bouncycastle"})

--- a/admin/kernel-syncdata-service/src/main/java/io/mosip/kernel/syncdata/repository/TemplateTypeRepository.java
+++ b/admin/kernel-syncdata-service/src/main/java/io/mosip/kernel/syncdata/repository/TemplateTypeRepository.java
@@ -26,7 +26,7 @@ public interface TemplateTypeRepository extends JpaRepository<TemplateType, Stri
 	List<TemplateType> findAllLatestCreatedUpdateDeleted(LocalDateTime lastUpdated, LocalDateTime currentTimeStamp);
 	
 	@Cacheable(cacheNames = "initial-sync", key = "'template_type'", condition = "#a0.getYear() <= 1970")
-	@Query(value = "select * from template_type WHERE (code IN (select distinct template_typ_code from template where module_id=?3)) AND ((cr_dtimes between ?1 AND ?2) OR (upd_dtimes between ?1 AND ?2)  OR (del_dtimes between ?1 AND ?2))", nativeQuery = true)
+	@Query(value = "select * from master.template_type WHERE (code IN (select distinct template_typ_code from master.template where module_id=?3)) AND ((cr_dtimes between ?1 AND ?2) OR (upd_dtimes between ?1 AND ?2)  OR (del_dtimes between ?1 AND ?2))", nativeQuery = true)
 	List<TemplateType> findAllLatestCreatedUpdateDeletedTemplateTypeCode(LocalDateTime lastUpdated, LocalDateTime currentTimeStamp, String regclientModuleId);
 
 	@Cacheable(cacheNames = "delta-sync", key = "'template_type'")

--- a/admin/kernel-syncdata-service/src/test/java/io/mosip/kernel/syncdata/test/TestBootApplication.java
+++ b/admin/kernel-syncdata-service/src/test/java/io/mosip/kernel/syncdata/test/TestBootApplication.java
@@ -26,7 +26,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 		"io.mosip.kernel.core", "io.mosip.kernel.crypto",
 		"io.mosip.kernel.signature.service","io.mosip.kernel.clientcrypto.service.impl",
 		"io.mosip.kernel.keymanagerservice.service", "io.mosip.kernel.keymanagerservice.util",
-		"io.mosip.kernel.keymanagerservice.helper", "io.mosip.kernel.keymanager",
+		"io.mosip.kernel.keymanagerservice.helper", "io.mosip.kernel.keymanager.hsm.impl",
 		"io.mosip.kernel.cryptomanager.util", "io.mosip.kernel.partnercertservice.helper",
 		"io.mosip.kernel.partnercertservice.service", "io.mosip.kernel.websub.api.client",
 		"io.mosip.kernel.keygenerator.bouncycastle"})

--- a/db_scripts/mosip_master/ddl/master-applicant_valid_document.sql
+++ b/db_scripts/mosip_master/ddl/master-applicant_valid_document.sql
@@ -6,7 +6,7 @@ CREATE TABLE master.applicant_valid_document(
 	apptyp_code character varying(36) NOT NULL,
 	doccat_code character varying(36) NOT NULL,
 	doctyp_code character varying(36) NOT NULL,
-	lang_code character varying(3) ,
+	lang_code character varying(3) NOT NULL,
 	is_active boolean NOT NULL,
 	cr_by character varying(256) NOT NULL,
 	cr_dtimes timestamp NOT NULL,

--- a/db_scripts/mosip_master/ddl/master-valid_document.sql
+++ b/db_scripts/mosip_master/ddl/master-valid_document.sql
@@ -5,7 +5,7 @@
 CREATE TABLE master.valid_document(
 	doctyp_code character varying(36) NOT NULL,
 	doccat_code character varying(36) NOT NULL,
-	lang_code character varying(3),
+	lang_code character varying(3) NOT NULL,
 	is_active boolean NOT NULL,
 	cr_by character varying(256) NOT NULL,
 	cr_dtimes timestamp NOT NULL,

--- a/db_upgrade_scripts/mosip_master/sql/1.1.5.5_to_1.2.0.1-B1_upgrade.sql
+++ b/db_upgrade_scripts/mosip_master/sql/1.1.5.5_to_1.2.0.1-B1_upgrade.sql
@@ -304,9 +304,6 @@ ALTER TABLE IF EXISTS master.zone_user DROP CONSTRAINT IF EXISTS pk_zoneuser;
 ALTER TABLE IF EXISTS master.zone_user ALTER COLUMN zone_code DROP NOT NULL;
 ALTER TABLE IF EXISTS master.zone_user ADD CONSTRAINT pk_zoneuser PRIMARY KEY (usr_id);
 
---- applicant_valid_document is no more in use, just required for backward compatibility
-ALTER TABLE IF EXISTS master.applicant_valid_document ALTER COLUMN lang_code DROP NOT NULL;
-
 SELECT * INTO master.ca_cert_store_migr_bkp FROM master.ca_cert_store;
 ALTER TABLE IF EXISTS master.ca_cert_store DROP COLUMN IF EXISTS signed_cert_data;
 ALTER TABLE IF EXISTS master.ca_cert_store DROP COLUMN IF EXISTS key_usage;
@@ -322,9 +319,3 @@ ALTER TABLE master.reg_working_nonworking ADD CONSTRAINT pk_working_nonworking P
 
 ALTER TABLE master.reg_working_nonworking DROP CONSTRAINT IF EXISTS fk_rwn_daycode;
 ALTER TABLE master.reg_working_nonworking DROP CONSTRAINT IF EXISTS fk_rwn_regcntr;
-
-SELECT * INTO master.valid_document_migr_bkp FROM master.valid_document;
-DELETE FROM master.valid_document where lang_code!=:'primary_language_code';
-ALTER TABLE master.valid_document DROP CONSTRAINT IF EXISTS pk_valdoc_code CASCADE;
-ALTER TABLE master.valid_document ALTER COLUMN lang_code DROP NOT NULL;
-ALTER TABLE master.valid_document ADD CONSTRAINT pk_valdoc_code PRIMARY KEY (doctyp_code,doccat_code);


### PR DESCRIPTION
1. Fixed test case failure MOSIP-27529
2. valid_document.lang_code setting as null is currently not supported in prereg version <=1.2.0.1 hence removing the constraint and fixed the API to use default langauge as language on create. MOSIP-28461 MOSIP-28369