### PR TITLE
MOSIP-28246: Removed commented unused variables from masterdata module

### DIFF
--- a/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
@@ -11,7 +11,6 @@ import java.security.PublicKey;
 import java.security.interfaces.RSAPublicKey;
 import java.util.ArrayList;
 import java.util.List;
-//import java.util.Map;
 import java.util.Properties;
 
 import org.apache.log4j.Level;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testscripts/PostWithFormDataAndFile.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testscripts/PostWithFormDataAndFile.java
@@ -24,7 +24,6 @@ import io.mosip.testrig.apirig.masterdata.utils.MasterDataConfigManager;
 import io.mosip.testrig.apirig.masterdata.utils.MasterDataUtil;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;

--- a/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testscripts/PostWithPathParamsAndBody.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testscripts/PostWithPathParamsAndBody.java
@@ -24,7 +24,6 @@ import io.mosip.testrig.apirig.masterdata.utils.MasterDataConfigManager;
 import io.mosip.testrig.apirig.masterdata.utils.MasterDataUtil;
 import io.mosip.testrig.apirig.testrunner.HealthChecker;
 import io.mosip.testrig.apirig.utils.AdminTestException;
-//import io.mosip.testrig.apirig.utils.AdminTestUtil;
 import io.mosip.testrig.apirig.utils.AuthenticationTestException;
 import io.mosip.testrig.apirig.utils.GlobalConstants;
 import io.mosip.testrig.apirig.utils.OutputValidationUtil;
@@ -78,7 +77,6 @@ public class PostWithPathParamsAndBody extends MasterDataUtil implements ITest {
 	@Test(dataProvider = "testcaselist")
 	public void test(TestCaseDTO testCaseDTO) throws AuthenticationTestException, AdminTestException, SecurityXSSException {
 		testCaseName = MasterDataUtil.isTestCaseValidForExecution(testCaseDTO);	
-//		String regCenterId = null;
 		if (HealthChecker.signalTerminateExecution) {
 			throw new SkipException(
 					GlobalConstants.TARGET_ENV_HEALTH_CHECK_FAILED + HealthChecker.healthCheckFailureMapS);


### PR DESCRIPTION
Removed commented-out and unused variable declarations from the Masterdata module as part of code hygiene and cleanup.