### PR TITLE
MOSIP-42428: MasterdataAPI – The 'GetMappedMachinesByRegCentID' test case is failing due to 'Machine not found' error

### DIFF
--- a/api-test/src/main/resources/masterdata/GetMappedMachinesByRegCentID/GetMappedMachinesByRegCentID.yml
+++ b/api-test/src/main/resources/masterdata/GetMappedMachinesByRegCentID/GetMappedMachinesByRegCentID.yml
@@ -9,7 +9,7 @@ GetMappedMachinesByRegCentID:
       inputTemplate: masterdata/GetMappedMachinesByRegCentID/getMappedMachinesByRegCentID
       outputTemplate: masterdata/GetMappedMachinesByRegCentID/getMappedMachinesByRegCentIDResult
       input: '{
-      "regCenterId":"10001"
+      "regCenterId":"$ID:CreateRegCenter_allValid_smoke_sid_id$"
 }'
       output: '{
 }'


### PR DESCRIPTION
Replaced hardcoded **regCenterId** in the test **Admin_GetMappedMachinesByRegCentID_allValid_smoke** with a dynamically fetched value from a dependent test.