### PR TITLE
MOSIP-44709: Fixed HealthCheck module mapping by using normalized module name instead of prefixed identifier.

### DIFF
--- a/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
+++ b/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
@@ -514,7 +514,7 @@ public class RegistrationCenterControllerTest {
 
 		MasterDataTest.checkResponse(
 				mockMvc.perform(MockMvcRequestBuilders.put("/registrationcenters/decommission/10003")).andReturn(),
-				"KER-MSD-351");
+				"KER-MSD-352");
 
 	}
 	

--- a/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
+++ b/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
@@ -514,7 +514,7 @@ public class RegistrationCenterControllerTest {
 
 		MasterDataTest.checkResponse(
 				mockMvc.perform(MockMvcRequestBuilders.put("/registrationcenters/decommission/10003")).andReturn(),
-				"KER-MSD-352");
+				"KER-MSD-351");
 
 	}
 	

--- a/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
@@ -83,7 +83,7 @@ public class MosipTestRunner {
 			setLogLevels();
 
 			HealthChecker healthcheck = new HealthChecker();
-			healthcheck.setCurrentRunningModule(BaseTestCase.currentModule);
+			healthcheck.setCurrentRunningModule(GlobalConstants.MASTERDATA);
 			Thread trigger = new Thread(healthcheck);
 			trigger.start();
 			

--- a/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
@@ -65,7 +65,7 @@ public class MosipTestRunner {
 	public static void main(String[] arg) {
 
 		try {
-			LOGGER.info("** ------------- API Test Rig Run Started --------------------------------------------- **");
+			LOGGER.info("** -------------- API Test Rig Run Started --------------------------------------------- **");
 			
 			BaseTestCase.setRunContext(getRunType(), jarUrl);
 			ExtractResource.removeOldMosipTestTestResource();

--- a/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
+++ b/api-test/src/main/java/io/mosip/testrig/apirig/masterdata/testrunner/MosipTestRunner.java
@@ -65,7 +65,7 @@ public class MosipTestRunner {
 	public static void main(String[] arg) {
 
 		try {
-			LOGGER.info("** -------------- API Test Rig Run Started --------------------------------------------- **");
+			LOGGER.info("** ------------- API Test Rig Run Started --------------------------------------------- **");
 			
 			BaseTestCase.setRunContext(getRunType(), jarUrl);
 			ExtractResource.removeOldMosipTestTestResource();


### PR DESCRIPTION
Fixes HealthCheck module mismatch by replacing the prefixed module name (BaseTestCase.currentModule) with a normalized value (GlobalConstants.MASTERDATA), ensuring correct mapping with healthCheckEndpoint.properties and proper endpoint filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated health monitoring module tracking in test infrastructure.

* **Chores**
  * Adjusted startup notification banner formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->