### PR TITLE
Corrected decommissionRegCenterFail_WithMappedRegCenter testcase [MOSIP-44916]

### DIFF
--- a/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
+++ b/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDate;
@@ -39,7 +38,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
 
 @RunWith(SpringRunner.class)
@@ -515,15 +513,9 @@ public class RegistrationCenterControllerTest {
 	@WithUserDetails("global-admin")
 	public void decommissionRegCenterFail_WithMappedRegCenter() throws Exception {
 
-		MvcResult result = mockMvc
-				.perform(MockMvcRequestBuilders.put("/registrationcenters/decommission/10003"))
-				.andReturn();
-
-		String body = result.getResponse().getContentAsString();
-		assertTrue(
-				"Expected KER-MSD-351 (machine mapped) or KER-MSD-352 (user mapped), got: " + body,
-				body.contains("KER-MSD-351") || body.contains("KER-MSD-352")
-		);
+		MasterDataTest.checkResponse(
+				mockMvc.perform(MockMvcRequestBuilders.put("/registrationcenters/decommission/10003")).andReturn(),
+				"KER-MSD-351");
 
 	}
 	

--- a/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
+++ b/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
@@ -29,6 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import java.time.LocalDate;
@@ -38,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doNothing;
 
 @RunWith(SpringRunner.class)
@@ -509,14 +511,19 @@ public class RegistrationCenterControllerTest {
 
 	}
 	
-	@Ignore
 	@Test
 	@WithUserDetails("global-admin")
 	public void decommissionRegCenterFail_WithMappedRegCenter() throws Exception {
 
-		MasterDataTest.checkResponse(
-				mockMvc.perform(MockMvcRequestBuilders.put("/registrationcenters/decommission/10003")).andReturn(),
-				"KER-MSD-351");
+		MvcResult result = mockMvc
+				.perform(MockMvcRequestBuilders.put("/registrationcenters/decommission/10003"))
+				.andReturn();
+
+		String body = result.getResponse().getContentAsString();
+		assertTrue(
+				"Expected KER-MSD-351 (machine mapped) or KER-MSD-352 (user mapped), got: " + body,
+				body.contains("KER-MSD-351") || body.contains("KER-MSD-352")
+		);
 
 	}
 	

--- a/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
+++ b/admin/kernel-masterdata-service/src/test/java/io/mosip/kernel/masterdata/test/controller/RegistrationCenterControllerTest.java
@@ -15,7 +15,6 @@ import io.mosip.kernel.masterdata.test.utils.MasterDataTest;
 import io.mosip.kernel.masterdata.utils.AuditUtil;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
@@ -27,6 +26,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -511,6 +511,8 @@ public class RegistrationCenterControllerTest {
 	
 	@Test
 	@WithUserDetails("global-admin")
+	@Sql(statements = "DELETE FROM master.user_detail WHERE regcntr_id='10003'",
+	executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 	public void decommissionRegCenterFail_WithMappedRegCenter() throws Exception {
 
 		MasterDataTest.checkResponse(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Re-enabled a previously disabled test for registration center decommissioning to improve coverage.
  * Added a test setup step to ensure a controlled database state before running the test.
  * Preserved existing expected error-response validation to maintain consistent verification of mapped registration-center behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->